### PR TITLE
Image download worker threads

### DIFF
--- a/server/RESTApi/cameraMonitor.js
+++ b/server/RESTApi/cameraMonitor.js
@@ -112,7 +112,7 @@ export function setSocketServer (serverSocket) {
                 log.error('Socket error (downloadStart):', error)
               }
 
-              // Download image data & generate filename
+              // Get image from camera & generate filename
               const imgData = file.downloadThumbnailToString()
               const fullFilePath = path.join(DOWNLOAD_DIR, getDownloadPath(), imgName)
               // setup callback for completion signal with exposure info via sockets
@@ -125,7 +125,8 @@ export function setSocketServer (serverSocket) {
                   log.error('Socket error (downloadEnd):', error)
                 }
               }
-              downloadImgThreaded(imgData, fullFilePath, imgInfoCallback).catch(err => console.error(err))
+              // Send Image to Worker Queue for download
+              downloadImgThreaded(imgData, fullFilePath, imgInfoCallback)
             }
           }
           break

--- a/server/RESTApi/cameraMonitor.js
+++ b/server/RESTApi/cameraMonitor.js
@@ -1,4 +1,3 @@
-import fs from 'fs'
 import path from 'path'
 
 // Temporary file name generation library
@@ -11,6 +10,7 @@ import camAPI from '@dimensional/napi-canon-cameras'
 import { setupEventMonitoring } from '../camSDK/SDKEventHelper.js'
 import { getCameraNickname, getCameraSummaryList, portList } from '../camSDK/SDKCameraHelper.js'
 import { getDownloadPath, getImageInfoFromFile } from '../util/fileHelper.js'
+import { downloadImgThreaded } from '../threading/workerController.js'
 import { setLiveViewCamera, stopLiveView } from './liveViewSocketStreamer.js'
 
 // Setup logging and environment variables
@@ -112,16 +112,11 @@ export function setSocketServer (serverSocket) {
                 log.error('Socket error (downloadStart):', error)
               }
 
-              // Download image data
+              // Download image data & generate filename
               const imgData = file.downloadThumbnailToString()
-              const imgBuffer = Buffer.from(imgData, 'base64')
-
-              // Save it to a file
               const fullFilePath = path.join(DOWNLOAD_DIR, getDownloadPath(), imgName)
-              fs.writeFileSync(fullFilePath, imgBuffer, { encoding: 'utf8' })
-
-              // Send completion signal with exposure info via sockets
-              getImageInfoFromFile(fullFilePath).then(exposureInfo => {
+              // setup callback for completion signal with exposure info via sockets
+              const imgInfoCallback = (exposureInfo) => {
                 try {
                   serverSocket
                     .to(['Download-*', `Download-${camIndex}`])
@@ -129,7 +124,8 @@ export function setSocketServer (serverSocket) {
                 } catch (error) {
                   log.error('Socket error (downloadEnd):', error)
                 }
-              })
+              }
+              downloadImgThreaded(imgData, fullFilePath, imgInfoCallback).catch(err => console.error(err))
             }
           }
           break

--- a/server/threading/WorkerWrapper.js
+++ b/server/threading/WorkerWrapper.js
@@ -1,0 +1,30 @@
+import { Worker } from 'worker_threads'
+
+export default class WorkerWrapper {
+  constructor(workerScript, rePoolCallback) {
+    this.worker = new Worker(workerScript)
+    this.rePoolCallback = rePoolCallback
+    this.imgInfoCallback = null
+
+    this.worker.on('message', (data) => {
+      if (data.success === true) {
+        this.imgInfoCallback(data.exposureInfo)
+        this.imgInfoCallback = null
+        this.rePoolCallback(this)
+      }
+    })
+    this.worker.on('error', (err) => {
+      console.error(err)
+    })
+    this.worker.on('exit', (code) => {
+      if (code !== 0) {
+        console.error(new Error(`stopped with ${code} exit code`))
+      }
+    })
+  }
+
+  runWorker(task) {
+    this.imgInfoCallback = task.imgInfoCallback
+    this.worker.postMessage(task.workerData)
+  }
+}

--- a/server/threading/WorkerWrapper.js
+++ b/server/threading/WorkerWrapper.js
@@ -1,11 +1,13 @@
 import { Worker } from 'worker_threads'
 
 export default class WorkerWrapper {
+  // Create a new worker and initialize callbacks
   constructor(workerScript, rePoolCallback) {
     this.worker = new Worker(workerScript)
     this.rePoolCallback = rePoolCallback
     this.imgInfoCallback = null
 
+    // If success message recieved, return data via callback, then rejoin worker pool
     this.worker.on('message', (data) => {
       if (data.success === true) {
         this.imgInfoCallback(data.exposureInfo)
@@ -13,6 +15,8 @@ export default class WorkerWrapper {
         this.rePoolCallback(this)
       }
     })
+    
+    // Handle Error & Exit
     this.worker.on('error', (err) => {
       console.error(err)
     })
@@ -23,6 +27,7 @@ export default class WorkerWrapper {
     })
   }
 
+  // Give a task to worker
   runWorker(task) {
     this.imgInfoCallback = task.imgInfoCallback
     this.worker.postMessage(task.workerData)

--- a/server/threading/imageDownloadWorker.js
+++ b/server/threading/imageDownloadWorker.js
@@ -1,0 +1,18 @@
+import fs from 'fs'
+import { parentPort } from 'worker_threads'
+import { getImageInfoFromFile } from '../util/fileHelper.js'
+
+parentPort.on('message', async (workerData) => {
+  const { filePath, imgData } = workerData
+  if (typeof imgData !== 'string' || typeof filePath !== 'string') {
+    throw new Error(`Invalid parameters imgData: ${imgData}, filePath: ${filePath}`)
+  }
+
+  const imgBuffer = Buffer.from(imgData, 'base64')
+  fs.writeFileSync(filePath, imgBuffer, { encoding: 'utf8' })
+  const exposureInfo = await getImageInfoFromFile(filePath)
+
+  // Report success
+  parentPort.postMessage({ success: true, exposureInfo})
+  
+})

--- a/server/threading/imageDownloadWorker.js
+++ b/server/threading/imageDownloadWorker.js
@@ -2,17 +2,21 @@ import fs from 'fs'
 import { parentPort } from 'worker_threads'
 import { getImageInfoFromFile } from '../util/fileHelper.js'
 
+// listen for new tasks
 parentPort.on('message', async (workerData) => {
+  // Verify task data
   const { filePath, imgData } = workerData
   if (typeof imgData !== 'string' || typeof filePath !== 'string') {
     throw new Error(`Invalid parameters imgData: ${imgData}, filePath: ${filePath}`)
   }
 
+  // Download image to file
   const imgBuffer = Buffer.from(imgData, 'base64')
   fs.writeFileSync(filePath, imgBuffer, { encoding: 'utf8' })
+
+  // Retrieve Exposure info from file
   const exposureInfo = await getImageInfoFromFile(filePath)
 
   // Report success
   parentPort.postMessage({ success: true, exposureInfo})
-  
 })

--- a/server/threading/workerController.js
+++ b/server/threading/workerController.js
@@ -4,19 +4,20 @@ import WorkerWrapper from './WorkerWrapper.js'
 // Hardcoded path to script (relative to working directory)
 const IMG_DOWNLOAD_SCRIPT_PATH = path.join(process.cwd(), 'server', 'threading', 'imageDownloadWorker.js')
 
-const taskQueue = []
-const workerPool = []
+// Initialize Worker Pool
 const POOL_SIZE = 16
-let finished = 0
-let requested = 0
+const workerPool = []
 for (let i = 0; i < POOL_SIZE; ++i) { workerPool.push(new WorkerWrapper(IMG_DOWNLOAD_SCRIPT_PATH, rePoolWorker)) }
 
+const taskQueue = []
+
+// Add Worker back to pool and check for new tasks
 function rePoolWorker(worker) {
-  console.log(`Downloading: ${finished}/${requested} | PoolAvailable: ${workerPool.length}/${POOL_SIZE}`)
   workerPool.push(worker)
   doNextTask()
 }
 
+// Pop next task, If a worker is available, assign the task, otherwise reQueue the task
 function doNextTask() {
   const nextTask = taskQueue.pop()
   if (nextTask !== undefined)
@@ -24,15 +25,14 @@ function doNextTask() {
     const nextWorker = workerPool.pop()
     if (nextWorker !== undefined) {
       nextWorker.runWorker(nextTask)
-      finished++
     } else {
       taskQueue.push(nextTask)
     }
   }
 }
 
+// Add new task to queue and check for available workers
 export async function downloadImgThreaded (imgData, filePath, imgInfoCallback) {
     taskQueue.push({workerData: {imgData, filePath}, imgInfoCallback})
-    requested++
     doNextTask()
 }

--- a/server/threading/workerController.js
+++ b/server/threading/workerController.js
@@ -1,0 +1,38 @@
+import path from 'path'
+import WorkerWrapper from './WorkerWrapper.js'
+
+// Hardcoded path to script (relative to working directory)
+const IMG_DOWNLOAD_SCRIPT_PATH = path.join(process.cwd(), 'server', 'threading', 'imageDownloadWorker.js')
+
+const taskQueue = []
+const workerPool = []
+const POOL_SIZE = 16
+let finished = 0
+let requested = 0
+for (let i = 0; i < POOL_SIZE; ++i) { workerPool.push(new WorkerWrapper(IMG_DOWNLOAD_SCRIPT_PATH, rePoolWorker)) }
+
+function rePoolWorker(worker) {
+  console.log(`Downloading: ${finished}/${requested} | PoolAvailable: ${workerPool.length}/${POOL_SIZE}`)
+  workerPool.push(worker)
+  doNextTask()
+}
+
+function doNextTask() {
+  const nextTask = taskQueue.pop()
+  if (nextTask !== undefined)
+  {
+    const nextWorker = workerPool.pop()
+    if (nextWorker !== undefined) {
+      nextWorker.runWorker(nextTask)
+      finished++
+    } else {
+      taskQueue.push(nextTask)
+    }
+  }
+}
+
+export async function downloadImgThreaded (imgData, filePath, imgInfoCallback) {
+    taskQueue.push({workerData: {imgData, filePath}, imgInfoCallback})
+    requested++
+    doNextTask()
+}


### PR DESCRIPTION
Image Downloads Events now download the image to a string, then submit the string and a file path to a queue for workers to download in parallel. Workers download the image to a file then extract the exif data and send it back for the main thread.

Image Downloading should now be fully implemented to satisfy and close #4 